### PR TITLE
Scala - Add scalaPB plugin, lib dep and compile target

### DIFF
--- a/pkg/services/scala/template/project/plugins.sbt
+++ b/pkg/services/scala/template/project/plugins.sbt
@@ -1,3 +1,5 @@
 logLevel := sbt.Level.Warn
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "{{ .SBTAssemblyVersion }}")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "{{ .SBTProtocPluginPackageVersion }}")
+
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "{{ .ScalaPBRuntimePackageVersion  }}"

--- a/pkg/services/scala/template/scalapb.sbt
+++ b/pkg/services/scala/template/scalapb.sbt
@@ -1,0 +1,3 @@
+PB.targets in Compile := Seq(
+  scalapb.gen() -> (sourceManaged in Compile).value
+)


### PR DESCRIPTION
For moar ScalaPB goodness (generate java, conversions, use different codegen plugins, etc.): https://github.com/thesamet/sbt-protoc

The current versions I used were:

`. SBTProtocPluginPackageVersion ` = `0.99.33`
`. ScalaPBRuntimePackageVersion ` = `0.10.0-M4`

I removed the `sbt-assembly` plugin since we shouldn't be publishing anything executable for Spark here, just the ScalaPB codegen stuff.